### PR TITLE
indexed-audio-sources

### DIFF
--- a/documents/cli.md
+++ b/documents/cli.md
@@ -6,8 +6,8 @@ The program is called `vpt`. You may launch it through your system's command lin
 
 To make sure your hardware is correctly functioning and recognized by the program, use the `check` option:
 
-```
-$ vpt check
+```sh
+vpt check
 ```
 
 This will record the data for 5 seconds and then create 3 files in your current working directory:
@@ -29,8 +29,8 @@ duration (in seconds).
 
 To launch the application, simply start the executable without any parameters:
 
-```
-$ vpt
+```sh
+vpt
 ```
 
 This will open a window with live graphs of data and buttons to start/stop recording. You may minimize the window and start working now.
@@ -43,21 +43,22 @@ If you have multiple audio/video sources, you can select between them.
 
 To list all available sources, use the `sources` option with the type (`audio` or `video`):
 
-```
+```sh
 $ vpt sources audio
-AudioSource1
-AudioSource2
-AudioSource3
+ID  Name
+ 1   AudioSource1
+ 2   AudioSource2
+ 3   AudioSource3
 $ vpt sources video
 Video source 1
 Video source 2
 ```
 
-To select an audio source for recording, use `--audio <NAME>` for specifying the audio source and `--video <NAME>` for
+To select an audio source for recording, use `--audio <ID>` for specifying the audio source and `--video <NAME>` for
 specifying the video source:
 
 ```sh
-$ vpt --audio AudioSource2 --video "Video source 2"
+vpt --audio 3 --video "Video source 2"
 ```
 
 ## Obtaining raw data for analysis
@@ -66,7 +67,7 @@ If you wish to get a dataset of keyboard/mouse activity along with the predicted
 audio/video, use the `dump` option:
 
 ```sh
-$ vpt dump
+vpt dump
 ```
 
 This will create a `vpt-data.sql` SQLite database in the current working directory with the collected data.

--- a/vpt/__main__.py
+++ b/vpt/__main__.py
@@ -15,4 +15,4 @@ elif args['cmd'] == 'check':
     check()
 elif args['cmd'] is None:
     # If no argument, fall back to recording
-    record(args['audio'], args['video'])
+    record(int(args['audio']), args['video'])

--- a/vpt/__main__.py
+++ b/vpt/__main__.py
@@ -2,9 +2,9 @@
 from vpt.cli.check import check
 from vpt.cli.cli import parse_args
 from vpt.cli.record import record
-from vpt.cli.sources import print_audio_inputs, print_video_inputs, get_default_audio_input_name
+from vpt.cli.sources import print_audio_inputs, print_video_inputs, get_default_audio_input_index
 
-args = parse_args(audio_default=get_default_audio_input_name())
+args = parse_args(audio_default=get_default_audio_input_index())
 
 if args['cmd'] == 'sources':
     if args['source'] == 'audio':

--- a/vpt/cli/check.py
+++ b/vpt/cli/check.py
@@ -14,11 +14,11 @@ def check():
     print('Checking the devices for 5s...')
 
     # Create capture nodes
-    audio_device = sd.query_devices(kind='input', device=args['audio'])
+    audio_device = sd.query_devices()[int(args['audio'])]
     video_source = DeviceVideoSource(int(args['video']))
     audio_source = DeviceAudioSource(audio_device['max_input_channels'],
                                      audio_device['default_samplerate'],
-                                     args['audio'])
+                                     int(args['audio']))
     keyboard_source = KeyboardSource()
     mouse_source = MouseSource()
 
@@ -29,9 +29,9 @@ def check():
     file_store = FileStore('.', mouse_source, keyboard_source, audio_source)
 
     # Run UI on the MainThread (this is a blocking call)
-    scheduler = ImmediateScheduler()
-    file_store.start(scheduler)
-    video_display.start(scheduler)
+    # scheduler = ImmediateScheduler()
+    file_store.start()
+    video_display.start()
 
     # Stop capture on all types of sources
     file_store.stop()

--- a/vpt/cli/cli.py
+++ b/vpt/cli/cli.py
@@ -14,7 +14,7 @@ def create_parser(audio_default=None):
                                     '"sources audio" subcommand')
     device_parser.add_argument('--video',
                                default=0,
-                               help='The name of the audio source, as reported by the '
+                               help='The name of the video source, as reported by the '
                                     '"sources video" subcommand')
 
     parser = ArgumentParser(prog='vpt',

--- a/vpt/cli/cli.py
+++ b/vpt/cli/cli.py
@@ -3,14 +3,14 @@ from argparse import ArgumentParser
 from typing import Sequence
 
 
-def create_parser(audio_default=None):
+def create_parser(audio_default=int):
     '''Creates and returns a parser for command line arguments.'''
     # pylint: disable=unused-variable; They are created for consistency and clarity
 
     device_parser = ArgumentParser(add_help=False)
     device_parser.add_argument('--audio',
                                default=audio_default,
-                               help='The name of the audio source, as reported by the '
+                               help='The ID of the audio source, as reported by the '
                                     '"sources audio" subcommand')
     device_parser.add_argument('--video',
                                default=0,
@@ -34,7 +34,8 @@ def create_parser(audio_default=None):
                               type=float,
                               help='Duration of the recording (in seconds)')
 
-    sources_parser = subparsers.add_parser('sources', description='List all available sources')
+    sources_parser = subparsers.add_parser(
+        'sources', description='List all available sources')
     sources_parser.add_argument('source', choices=['audio', 'video'])
 
     dump_parser = subparsers.add_parser('dump',

--- a/vpt/cli/record.py
+++ b/vpt/cli/record.py
@@ -11,12 +11,12 @@ from matplotlib.backends.backend_qt5 import QtCore, QtWidgets
 from vpt.processors import EngagementEstimator, GazeDetector, SpeechDetector, MouseCompressor
 from vpt.sinks import GraphView, CSVStore
 from vpt.sources import DeviceVideoSource, KeyboardSource, MouseSource, DeviceAudioSource
+from vpt.cli.sources import get_default_audio_input_index
 
 
-def record(audio_source: Union[str, int], video_source_id: int):
+def record(audio_source: int, video_source_id: int):
     """Runs all of the recorders to check that everything works correctly."""
-    audio_device = sd.query_devices(kind='input',
-                                    device=[d['name'] for d in sd.query_devices()].index(audio_source))
+    audio_device = sd.query_devices()[audio_source]
 
     # Create capture nodes
     video_source = DeviceVideoSource(video_source_id)

--- a/vpt/cli/record.py
+++ b/vpt/cli/record.py
@@ -2,16 +2,13 @@
 
 import sys
 from datetime import datetime
-from typing import Union
 
 import sounddevice as sd
-from rx.scheduler.mainloop import QtScheduler
-from matplotlib.backends.backend_qt5 import QtCore, QtWidgets
+from matplotlib.backends.backend_qt5 import QtWidgets
 
 from vpt.processors import EngagementEstimator, GazeDetector, SpeechDetector, MouseCompressor
 from vpt.sinks import GraphView, CSVStore
 from vpt.sources import DeviceVideoSource, KeyboardSource, MouseSource, DeviceAudioSource
-from vpt.cli.sources import get_default_audio_input_index
 
 
 def record(audio_source: int, video_source_id: int):

--- a/vpt/cli/sources.py
+++ b/vpt/cli/sources.py
@@ -16,27 +16,29 @@ def list_audio_inputs() -> List[dict]:
     devices = sd.query_devices()
     default = sd.query_devices(kind='input')
     devices = [device for device in devices if device['max_input_channels'] > 0]
-    for device in devices:
+    for i, device in enumerate(devices):
         if device == default:
             device['default'] = True
         else:
             device['default'] = False
+        device['index'] = i
     return devices
 
 
 def print_audio_inputs():
     '''Prints the available input devices in a nice table.'''
     devices = list_audio_inputs()
-    print(f'┌{"-" * 5}┬{"-" * 52}┬{"-" * 12}┬{"-" * 14}┐')
-    print(f'| {"#":^3} | {"Name":^50} | {"Channels":^10} | {"Sample rate":^12} |')
-    print(f'├{"-" * 5}┼{"-" * 52}┼{"-" * 12}┼{"-" * 14}┤')
-    for i, device in enumerate(devices):
-        index = str(i) + (" *" if device['default'] else "")
+    print(f'┌{"-" * 6}┬{"-" * 52}┬{"-" * 12}┬{"-" * 14}┐')
+    print(f'| {"#":^4} | {"Name":^50} | {"Channels":^10} | {"Sample rate":^12} |')
+    print(f'├{"-" * 6}┼{"-" * 52}┼{"-" * 12}┼{"-" * 14}┤')
+    for device in devices:
+        if device['default']:
+            device['index'] = str(device['index']) + ' *'
         device['name'] = shorten(device['name'], width=50, placeholder='..')
-        print(f'| {index:<3} |{device["name"]:<51} '
+        print(f'| {device["index"]:<4} |{device["name"]:<51} '
               f'| {device["max_input_channels"]:^10} '
               f'| {device["default_samplerate"]:^12} |')
-    print(f'└{"-" * 5}┴{"-" * 52}┴{"-" * 12}┴{"-" * 14}┘')
+    print(f'└{"-" * 6}┴{"-" * 52}┴{"-" * 12}┴{"-" * 14}┘')
     print('* = default')
 
 

--- a/vpt/cli/sources.py
+++ b/vpt/cli/sources.py
@@ -6,22 +6,26 @@ import cv2
 import sounddevice as sd
 
 
-def get_default_audio_input_name() -> str:
+def get_default_audio_input_index() -> int:
     '''Gets the name of the default audio input device.'''
-    return sd.query_devices(kind='input')['name']
+    inputs = list_audio_inputs()
+    default = next(i for i in inputs if i['default'])
+    return default['index']
 
 
 def list_audio_inputs() -> List[dict]:
     '''Returns a list of all audio input devices.'''
     devices = sd.query_devices()
     default = sd.query_devices(kind='input')
-    devices = [device for device in devices if device['max_input_channels'] > 0]
+
     for i, device in enumerate(devices):
         if device == default:
             device['default'] = True
         else:
             device['default'] = False
         device['index'] = i
+
+    devices = [device for device in devices if device['max_input_channels'] > 0]
     return devices
 
 

--- a/vpt/cli/sources.py
+++ b/vpt/cli/sources.py
@@ -27,16 +27,16 @@ def list_audio_inputs() -> List[dict]:
 def print_audio_inputs():
     '''Prints the available input devices in a nice table.'''
     devices = list_audio_inputs()
-    print(f'┌{"-" * 52}┬{"-" * 12}┬{"-" * 14}┐')
-    print(f'| {"Name":^50} | {"Channels":^10} | {"Sample rate":^12} |')
-    print(f'├{"-" * 52}┼{"-" * 12}┼{"-" * 14}┤')
-    for device in devices:
-        if device['default']:
-            device['name'] = '* ' + device['name']
+    print(f'┌{"-" * 5}┬{"-" * 52}┬{"-" * 12}┬{"-" * 14}┐')
+    print(f'| {"#":^3} | {"Name":^50} | {"Channels":^10} | {"Sample rate":^12} |')
+    print(f'├{"-" * 5}┼{"-" * 52}┼{"-" * 12}┼{"-" * 14}┤')
+    for i, device in enumerate(devices):
+        index = str(i) + (" *" if device['default'] else "")
         device['name'] = shorten(device['name'], width=50, placeholder='..')
-        print(f'| {device["name"]:<50} | {device["max_input_channels"]:^10} '
+        print(f'| {index:<3} |{device["name"]:<51} '
+              f'| {device["max_input_channels"]:^10} '
               f'| {device["default_samplerate"]:^12} |')
-    print(f'└{"-" * 52}┴{"-" * 12}┴{"-" * 14}┘')
+    print(f'└{"-" * 5}┴{"-" * 52}┴{"-" * 12}┴{"-" * 14}┘')
     print('* = default')
 
 

--- a/vpt/cli/sources.py
+++ b/vpt/cli/sources.py
@@ -33,17 +33,17 @@ def print_audio_inputs():
     '''Prints the available input devices in a nice table.'''
     devices = list_audio_inputs()
     print(f'┌{"-" * 6}┬{"-" * 52}┬{"-" * 12}┬{"-" * 14}┐')
-    print(f'| {"#":^4} | {"Name":^50} | {"Channels":^10} | {"Sample rate":^12} |')
+    print(f'| {"ID":^4} | {"Name":^50} | {"Channels":^10} | {"Sample rate":^12} |')
     print(f'├{"-" * 6}┼{"-" * 52}┼{"-" * 12}┼{"-" * 14}┤')
     for device in devices:
         if device['default']:
-            device['index'] = str(device['index']) + ' *'
+            device['index'] = str(device['index']) + ' ✔'
         device['name'] = shorten(device['name'], width=50, placeholder='..')
         print(f'| {device["index"]:<4} |{device["name"]:<51} '
               f'| {device["max_input_channels"]:^10} '
               f'| {device["default_samplerate"]:^12} |')
     print(f'└{"-" * 6}┴{"-" * 52}┴{"-" * 12}┴{"-" * 14}┘')
-    print('* = default')
+    print('✔ = default')
 
 
 def list_video_inputs():

--- a/vpt/processors/speech_detector.py
+++ b/vpt/processors/speech_detector.py
@@ -63,14 +63,18 @@ class SpeechDetector(ProcessorBase[bool]):
         if frame.ndim == 1:
             frame = frame.reshape(len(frame), 1)
 
-        freqs = self.fft(frame.mean(axis=1))
+        try:
+            freqs = self.fft(frame.mean(axis=1))
+        except ValueError:
+            return
         this_loudness = freqs.max(axis=0)
 
         if self.is_silence(this_loudness):
             self._subj.on_next(False)
         else:
             freqs_norm = self.normalize_frequencies(freqs)
-            self._subj.on_next(np.any(freqs_norm[VOICE_RANGE] >= self.noise_threshold))
+            self._subj.on_next(
+                np.any(freqs_norm[VOICE_RANGE] >= self.noise_threshold))
         self.update_mean(this_loudness)
 
     def update_mean(self, new_loudness):

--- a/vpt/sinks/graph_view.py
+++ b/vpt/sinks/graph_view.py
@@ -32,7 +32,8 @@ class GraphView(SinkBase):
         self.last_keyboard_time = 0
         self.last_mouse_time = 0
         self.points_in_buffer = 20
-        self.buffer = deque([(0, 0)] * self.points_in_buffer, maxlen=self.points_in_buffer)
+        self.buffer = deque([(0, 0)] * self.points_in_buffer,
+                            maxlen=self.points_in_buffer)
 
     def start(self):
         if not self.stopped:
@@ -46,12 +47,13 @@ class GraphView(SinkBase):
                                                 time=time.time())
         self.subscriptions = [
             mouse_source.output.pipe(operators.start_with(initial_mouse_event))
-                .pipe(operators.combine_latest(
-                    keyboard_source.output.pipe(operators.start_with(initial_keyboard_event)),
-                    engagement_source.output
-                ))
-                .pipe(operators.throttle_first(0.1))  # in seconds
-                .subscribe(self.update)
+            .pipe(operators.combine_latest(
+                keyboard_source.output.pipe(
+                    operators.start_with(initial_keyboard_event)),
+                engagement_source.output
+            ))
+            .pipe(operators.throttle_first(0.1))  # in seconds
+            .subscribe(self.update)
         ]
 
         if self.window is None:
@@ -66,8 +68,10 @@ class GraphView(SinkBase):
         '''Change button text'''
         if not self.stopped:
             self.stop()
+            self.window.record_button.setText('Start recording')
         else:
             self.start()
+            self.window.record_button.setText('Stop recording')
 
     def narrow_data(self, data):
         '''Get 2 points 0/1 from data.'''
@@ -94,6 +98,7 @@ class GraphView(SinkBase):
         self.buffer.append(point)
         self.window.plot(self.buffer)
 
+
 class Window(QtWidgets.QMainWindow):
     '''Graph frontend window'''
 
@@ -103,9 +108,9 @@ class Window(QtWidgets.QMainWindow):
         self.setCentralWidget(_main)
         layout = QtWidgets.QVBoxLayout(_main)
 
-        record_button = QtWidgets.QPushButton("Start/stop recording")
-        record_button.clicked.connect(toggle_callback)
-        layout.addWidget(record_button)
+        self.record_button = QtWidgets.QPushButton("Stop recording")
+        self.record_button.clicked.connect(toggle_callback)
+        layout.addWidget(self.record_button)
 
         figure, [self.axs_inp, self.axs_eng] = plt.subplots(
             1, 2, sharex=True, sharey=True, figsize=(5, 2))
@@ -119,8 +124,10 @@ class Window(QtWidgets.QMainWindow):
         self.axs_eng.set_title("Engagement", fontsize=10)
         self.set_axis_ticks(self.axs_eng)
 
-        self.line_inp, *_ = self.axs_inp.plot(range(self.points), np.zeros(self.points))
-        self.line_eng, *_ = self.axs_eng.plot(range(self.points), np.zeros(self.points))
+        self.line_inp, * \
+            _ = self.axs_inp.plot(range(self.points), np.zeros(self.points))
+        self.line_eng, * \
+            _ = self.axs_eng.plot(range(self.points), np.zeros(self.points))
 
     @staticmethod
     def set_axis_ticks(axis: Axes):

--- a/vpt/sources/device_audio_source.py
+++ b/vpt/sources/device_audio_source.py
@@ -14,12 +14,12 @@ from vpt.sources.base import SourceBase
 class DeviceAudioSource(SourceBase[np.ndarray]):
     '''A data source for the audio stream from the device.'''
     _subj: Subject
-    device: Union[str, int]
+    device: int
     channels: int
     sample_rate: float
     _thread: threading.Thread
 
-    def __init__(self, channels: int, sample_rate: float, device: Union[str, int] = None):
+    def __init__(self, channels: int, sample_rate: float, device: int = None):
         self.stopped = True
         self._subj = Subject()
         self.device = device
@@ -38,7 +38,7 @@ class DeviceAudioSource(SourceBase[np.ndarray]):
             rec = sd.rec(int(sample_duration * self.sample_rate),
                          samplerate=self.sample_rate,
                          channels=self.channels,
-                         device=[d['name'] for d in sd.query_devices()].index(self.device),
+                         device=self.device,
                          blocking=True)
 
             rec = self.trim_corruption(rec)


### PR DESCRIPTION
Change audio sources selection & identification to utilize their ID (indexes) instead of string names to fix application malfunction on machines with Russian (and probably with other non-English) system languages. CLI documentation and audio sources display updated accordingly.

To display audio sources:
`pipenv run vpt sources audio`
![image](https://user-images.githubusercontent.com/32439229/111025549-e2c94700-83f5-11eb-88b6-1ef283108212.png)
Then to start recording using a specific audio source:
`pipenv run vpt --audio 5` 